### PR TITLE
WIP: remove deprecated readFile/writeFile/getPackageJson (after deprecation)

### DIFF
--- a/packages/sv-utils/api-surface.md
+++ b/packages/sv-utils/api-surface.md
@@ -812,18 +812,6 @@ declare function loadPackageJson(cwd: string): {
   data: Package;
   generateCode: () => string;
 };
-/**
- * @deprecated Use {@link loadFile} instead. This alias will be removed in a future version.
- */
-declare const readFile: typeof loadFile;
-/**
- * @deprecated Use {@link saveFile} instead. This alias will be removed in a future version.
- */
-declare const writeFile: typeof saveFile;
-/**
- * @deprecated Use {@link loadPackageJson} instead. This alias will be removed in a future version.
- */
-declare const getPackageJson: typeof loadPackageJson;
 type ColorInput = string | string[];
 declare const color: {
   addon: (str: ColorInput) => string;
@@ -869,7 +857,6 @@ export {
   detect,
   downloadJson,
   fileExists,
-  getPackageJson,
   index_d_exports$2 as html,
   isVersionUnsupportedBelow,
   index_d_exports$3 as js,
@@ -877,7 +864,6 @@ export {
   loadFile,
   loadPackageJson,
   parse,
-  readFile,
   resolveCommand,
   resolveCommandArray,
   sanitizeName,
@@ -886,6 +872,5 @@ export {
   index_d_exports$4 as svelte,
   text_d_exports as text,
   transforms,
-  writeFile,
 };
 ```

--- a/packages/sv-utils/src/files.ts
+++ b/packages/sv-utils/src/files.ts
@@ -69,18 +69,3 @@ export function loadPackageJson(cwd: string): {
 	const { data, generateCode } = parseJson(packageText);
 	return { source: packageText, data: data as Package, generateCode };
 }
-
-/**
- * @deprecated Use {@link loadFile} instead. This alias will be removed in a future version.
- */
-export const readFile: typeof loadFile = loadFile;
-
-/**
- * @deprecated Use {@link saveFile} instead. This alias will be removed in a future version.
- */
-export const writeFile: typeof saveFile = saveFile;
-
-/**
- * @deprecated Use {@link loadPackageJson} instead. This alias will be removed in a future version.
- */
-export const getPackageJson: typeof loadPackageJson = loadPackageJson;

--- a/packages/sv-utils/src/index.ts
+++ b/packages/sv-utils/src/index.ts
@@ -79,19 +79,6 @@ export {
 	type Package
 } from './files.ts';
 
-/**
- * @deprecated Use {@link loadFile} instead. This alias will be removed in a future version.
- */
-export { readFile } from './files.ts';
-/**
- * @deprecated Use {@link saveFile} instead. This alias will be removed in a future version.
- */
-export { writeFile } from './files.ts';
-/**
- * @deprecated Use {@link loadPackageJson} instead. This alias will be removed in a future version.
- */
-export { getPackageJson } from './files.ts';
-
 // Terminal styling
 export { color } from './color.ts';
 


### PR DESCRIPTION
WIP track surface API — **removal after deprecation**.

**Base** `chore/coupling-v1` (full coupling stack *with* deprecated aliases still exported).  
**Head** `chore/coupling-v2` drops `readFile` / `writeFile` / `getPackageJson` from `@sveltejs/sv-utils` and refreshes `api-surface.md`.

Pair with **#10** (deprecation introduction only).